### PR TITLE
Update command_helper.go

### DIFF
--- a/pkg/utils/command/command_helper.go
+++ b/pkg/utils/command/command_helper.go
@@ -39,7 +39,7 @@ func ExecResultStr(cmdStr string) (string, error) {
 
 // exec smart
 func ExecSmartCTLByPath(path string) []byte {
-	timeout := 3
+	timeout := 6
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(timeout)*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
部分硬盘休眠状态执行3秒不够   造成SmartCTL每10分钟执行一次 休眠一直被唤醒

Signed-off-by: kxxensys <79914398+kxxensys@users.noreply.github.com>