### PR TITLE
fix: no temperature when system disk isn't MMC and USB

### DIFF
--- a/route/v1/disk.go
+++ b/route/v1/disk.go
@@ -85,6 +85,7 @@ func GetDiskList(c *gin.Context) {
 					disk.DiskType = "USB"
 				}
 				disk.Health = "true"
+
 				disks = append(disks, disk)
 				continue
 			}


### PR DESCRIPTION
```go
		if systemDisk == nil {
			// go 5 level deep to look for system block device by mount point being "/"
			systemDisk := service.WalkDisk(currentDisk, 5, func(blk model1.LSBLKModel) bool { return blk.MountPoint == "/" })

			if systemDisk != nil {
				disk.Model = "System"
				if strings.Contains(systemDisk.SubSystems, "mmc") {
					disk.DiskType = "MMC"
				} else if strings.Contains(systemDisk.SubSystems, "usb") {
					disk.DiskType = "USB"
				}
				
                                disk.Health = "true"
				disks = append(disks, disk)
				continue
				}
			}
		}
```
The old code judge system disk is MMC and USB. and skip the fetch temperature stage. But some systems disk are a normal SSD or HHD. So add a condition to skip only when the type is MMC and USB