### PR TITLE
fix: keep system storage out of merged data

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,15 +3,82 @@ name: goreleaser
 on:
   push:
     tags:
-      - v*.*.*
+      - "v*.*.*"
+  workflow_dispatch:
+
 permissions:
   contents: write
+
 jobs:
-  call-workflow-passing-data:
-    uses: IceWhaleTech/github/.github/workflows/go_release.yml@main
-    with:
-      project-name: CasaOS-LocalStorage
-      file-name: casaos-local-storage
-    secrets:
-      OSS_KEY_ID: ${{ secrets.OSS_KEY_ID }}
-      OSS_KEY_SECRET: ${{ secrets.OSS_KEY_SECRET }}
+  release:
+    name: Build and publish LocalStorage packages
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Generate APIs and run tests
+        run: |
+          set -euo pipefail
+          go generate
+          go test ./...
+
+      - name: Build release packages
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          output_dir=/tmp/casaos-local-storage-release
+          mkdir -p "$output_dir"
+
+          build_target() {
+            local target_arch="$1"
+            local goarch="$2"
+            local goarm="${3:-}"
+            local stage_dir
+            local output_file="$output_dir/linux-${target_arch}-casaos-local-storage-${RELEASE_TAG}.tar.gz"
+
+            stage_dir="$(mktemp -d)"
+            cp -a build "$stage_dir/"
+
+            CGO_ENABLED=0 \
+              GOOS=linux \
+              GOARCH="$goarch" \
+              GOARM="$goarm" \
+              go build \
+                -buildvcs=false \
+                -trimpath \
+                -tags "musl netgo osusergo" \
+                -ldflags "-s -w -X main.commit=${GITHUB_SHA} -X main.date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                -o "$stage_dir/build/sysroot/usr/bin/casaos-local-storage" \
+                .
+
+            tar -C "$stage_dir" -czf "$output_file" build
+            rm -rf "$stage_dir"
+          }
+
+          build_target amd64 amd64
+          build_target arm64 arm64
+          build_target arm-7 arm 7
+          (cd "$output_dir" && sha256sum *.tar.gz > checksums.txt)
+
+      - name: Publish release assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          files: |
+            /tmp/casaos-local-storage-release/*.tar.gz
+            /tmp/casaos-local-storage-release/checksums.txt
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true

--- a/api/local_storage/openapi.yaml
+++ b/api/local_storage/openapi.yaml
@@ -76,7 +76,10 @@ paths:
     post:
       summary: Set a merge
       description: |-
-        (TODO)
+        Updates the complete source selection for a merge. For the default
+        /DATA merge, sending an explicit empty source_volume_uuids array and
+        an empty source_base_path performs a full unmerge. External storage
+        contents are not deleted.
       operationId: setMerge
       tags:
         - Merge methods
@@ -107,7 +110,10 @@ paths:
     post:
       summary: Initialize a merge
       description: |-
-        (TODO)
+        Prepares /DATA for a merge by moving the existing system-data tree to
+        /var/lib/casaos/files. The mergerfs mount is created by Set a merge
+        using the selected source volumes; the system-data path is not added
+        as a mergerfs branch automatically.
       operationId: initMerge
       tags:
         - Merge methods
@@ -452,9 +458,17 @@ components:
           example: "/DATA"
         source_base_path:
           type: string
-          example: "/var/lib/casaos/files"
+          description: |-
+            Optional system-data source. Leave empty to keep the system-data
+            tree outside the mergerfs branches; CasaOS exposes its AppData
+            directory at /DATA/AppData with a compatibility bind mount.
+          example: ""
         source_volume_uuids:
           type: array
+          description: |-
+            Complete list of CasaOS storage UUIDs to use as mergerfs branches.
+            For /DATA, an explicit empty list together with an empty
+            source_base_path removes the merge.
           items:
             type: string
             example: 5c682e86-cec3-4761-9350-8e1a0c2d1ae9

--- a/build/scripts/setup/script.d/04-setup-local-storage.sh
+++ b/build/scripts/setup/script.d/04-setup-local-storage.sh
@@ -8,37 +8,50 @@ readonly BUILD_PATH
 readonly APP_NAME_SHORT=local-storage
 
 __get_setup_script_directory_by_os_release() {
-	pushd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" >/dev/null
+	local service_directory
+	local os_release_file
+	local candidate
+	local distro
+	local candidates=()
 
-	{
-		# shellcheck source=/dev/null
-		{
-			source /etc/os-release
-			{
-				pushd "${ID}"/"${VERSION_CODENAME}" >/dev/null
-			} || {
-				pushd "${ID}" >/dev/null
-			} || {
-                [[ -n ${ID_LIKE} ]] && for ID in ${ID_LIKE}; do
-				    pushd "${ID}" >/dev/null && break
-                done
-			} || {
-				echo "Unsupported OS: ${ID} ${VERSION_CODENAME} (${ID_LIKE})"
-				exit 1
-			}
+	if [[ -n ${CASAOS_SETUP_SERVICE_DIRECTORY:-} ]]; then
+		service_directory=$(cd "${CASAOS_SETUP_SERVICE_DIRECTORY}" && pwd -P)
+	else
+		service_directory=$(cd "$(dirname "${BASH_SOURCE[0]}")/../service.d/${APP_NAME_SHORT}" && pwd -P)
+	fi
+	os_release_file=${CASAOS_OS_RELEASE_FILE:-/etc/os-release}
 
-			pwd
+	if [[ ! -r "${os_release_file}" ]]; then
+		echo "Unsupported OS: unable to read ${os_release_file}" >&2
+		return 1
+	fi
 
-			popd >/dev/null
+	# shellcheck source=/dev/null
+	source "${os_release_file}"
 
-		} || {
-			echo "Unsupported OS: unknown"
-			exit 1
-		}
+	if [[ -n ${ID:-} && -n ${VERSION_CODENAME:-} ]]; then
+		candidates+=("${ID}/${VERSION_CODENAME}")
+	fi
+	if [[ -n ${ID:-} ]]; then
+		candidates+=("${ID}")
+	fi
+	for distro in ${ID_LIKE:-}; do
+		if [[ -n ${VERSION_CODENAME:-} ]]; then
+			candidates+=("${distro}/${VERSION_CODENAME}")
+		fi
+		candidates+=("${distro}")
+	done
 
-	}
+	for candidate in "${candidates[@]}"; do
+		if [[ -f "${service_directory}/${candidate}/setup-${APP_NAME_SHORT}.sh" ]]; then
+			cd "${service_directory}/${candidate}"
+			pwd -P
+			return 0
+		fi
+	done
 
-	popd >/dev/null
+	echo "Unsupported OS: ${ID:-unknown} ${VERSION_CODENAME:-unknown} (${ID_LIKE:-})" >&2
+	return 1
 }
 
 SETUP_SCRIPT_DIRECTORY=$(__get_setup_script_directory_by_os_release)

--- a/pkg/mergerfs/mergerfs.go
+++ b/pkg/mergerfs/mergerfs.go
@@ -2,12 +2,18 @@ package mergerfs
 
 import (
 	"bytes"
+	"errors"
 	"path/filepath"
 	"strings"
 	"syscall"
 
 	"github.com/IceWhaleTech/CasaOS-Common/utils/logger"
 	"go.uber.org/zap"
+)
+
+const (
+	legacySourceKey = "user.mergerfs.srcmounts"
+	branchesKey     = "user.mergerfs.branches"
 )
 
 func ControlFile(fspath string) string {
@@ -46,21 +52,20 @@ func ListValues(fspath string) (map[string]string, error) {
 func SetSource(fspath string, sources []string) error {
 	ctrlfile := ControlFile(fspath)
 
-	key := "user.mergerfs.branches"
-
-	sourceMap := make(map[string]interface{})
-	for _, source := range sources {
-		sourceMap[source] = true
+	values, err := ListValues(fspath)
+	if err != nil {
+		return err
 	}
 
-	dedupedSources := make([]string, 0)
-	for source := range sourceMap {
-		dedupedSources = append(dedupedSources, source)
+	key, err := sourceKey(values)
+	if err != nil {
+		return err
 	}
 
+	dedupedSources := dedupeSources(sources)
 	value := []byte(strings.Join(dedupedSources, ":"))
 	//str, err := command.ExecResultStr("setfattr -n " + key + " -v " + string(string(value)) + " " + ctrlfile)
-	err := syscall.Setxattr(ctrlfile, key, value, 0)
+	err = syscall.Setxattr(ctrlfile, key, value, 0)
 	//logger.Error("SetSourceStr", zap.String("str", str))
 	if err != nil {
 		logger.Error("SetSource", zap.Error(err))
@@ -75,13 +80,27 @@ func GetSource(fspath string) ([]string, error) {
 		return nil, err
 	}
 
-	return strings.Split(values["user.mergerfs.srcmounts"], ":"), nil
+	key, err := sourceKey(values)
+	if err != nil {
+		return nil, err
+	}
+
+	return normalizeSources(values[key]), nil
 }
 
 func AddSource(fspath string, source string) error {
 	ctrlfile := ControlFile(fspath)
 
-	key := "user.mergerfs.branches"
+	values, err := ListValues(fspath)
+	if err != nil {
+		return err
+	}
+
+	key, err := sourceKey(values)
+	if err != nil {
+		return err
+	}
+
 	value := []byte("+" + source)
 
 	return syscall.Setxattr(ctrlfile, key, value, 0)
@@ -90,10 +109,62 @@ func AddSource(fspath string, source string) error {
 func RemoveSource(fspath string, source string) error {
 	ctrlfile := ControlFile(fspath)
 
-	key := "user.mergerfs.branches"
+	values, err := ListValues(fspath)
+	if err != nil {
+		return err
+	}
+
+	key, err := sourceKey(values)
+	if err != nil {
+		return err
+	}
+
 	value := []byte("-" + source)
 
 	return syscall.Setxattr(ctrlfile, key, value, 0)
+}
+
+func sourceKey(values map[string]string) (string, error) {
+	if _, ok := values[branchesKey]; ok {
+		return branchesKey, nil
+	}
+
+	if _, ok := values[legacySourceKey]; ok {
+		return legacySourceKey, nil
+	}
+
+	return "", errors.New("mergerfs source control xattr not found")
+}
+
+func normalizeSources(value string) []string {
+	if value == "" {
+		return []string{}
+	}
+
+	sources := strings.Split(value, ":")
+	for i, source := range sources {
+		for _, suffix := range []string{"=RW", "=RO", "=NC"} {
+			source = strings.TrimSuffix(source, suffix)
+		}
+		sources[i] = source
+	}
+
+	return sources
+}
+
+func dedupeSources(sources []string) []string {
+	deduped := make([]string, 0, len(sources))
+	seen := make(map[string]struct{}, len(sources))
+
+	for _, source := range sources {
+		if _, ok := seen[source]; ok {
+			continue
+		}
+		seen[source] = struct{}{}
+		deduped = append(deduped, source)
+	}
+
+	return deduped
 }
 
 func AddPath(fspath string, path string) error {

--- a/pkg/mergerfs/mergerfs_test.go
+++ b/pkg/mergerfs/mergerfs_test.go
@@ -1,0 +1,81 @@
+package mergerfs
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestSourceKeyPrefersModernBranchesKey(t *testing.T) {
+	values := map[string]string{
+		legacySourceKey: "/mnt/old",
+		branchesKey:     "/mnt/new=RW",
+	}
+
+	got, err := sourceKey(values)
+	if err != nil {
+		t.Fatalf("sourceKey() error = %v", err)
+	}
+	if got != branchesKey {
+		t.Fatalf("sourceKey() = %q, want %q", got, branchesKey)
+	}
+}
+
+func TestSourceKeyFallsBackToLegacyKey(t *testing.T) {
+	got, err := sourceKey(map[string]string{legacySourceKey: "/mnt/old"})
+	if err != nil {
+		t.Fatalf("sourceKey() error = %v", err)
+	}
+	if got != legacySourceKey {
+		t.Fatalf("sourceKey() = %q, want %q", got, legacySourceKey)
+	}
+}
+
+func TestSourceKeyRejectsUnknownControlInterface(t *testing.T) {
+	if _, err := sourceKey(map[string]string{}); err == nil {
+		t.Fatal("sourceKey() error = nil, want an error")
+	}
+}
+
+func TestNormalizeSourcesRemovesModernBranchModes(t *testing.T) {
+	got := normalizeSources("/mnt/a=RW:/mnt/b=RO:/mnt/c=NC:/mnt/name=kept")
+	want := []string{"/mnt/a", "/mnt/b", "/mnt/c", "/mnt/name=kept"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalizeSources() = %#v, want %#v", got, want)
+	}
+}
+
+func TestDedupeSourcesPreservesOrder(t *testing.T) {
+	got := dedupeSources([]string{"/mnt/a", "/mnt/b", "/mnt/a", "/mnt/c"})
+	want := []string{"/mnt/a", "/mnt/b", "/mnt/c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("dedupeSources() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLiveMountSourceControl(t *testing.T) {
+	mountPoint := os.Getenv("MERGERFS_TEST_MOUNT")
+	if mountPoint == "" {
+		t.Skip("MERGERFS_TEST_MOUNT is not set")
+	}
+
+	sources, err := GetSource(mountPoint)
+	if err != nil {
+		t.Fatalf("GetSource() error = %v", err)
+	}
+	if len(sources) == 0 {
+		t.Fatal("GetSource() returned no sources")
+	}
+
+	if err := SetSource(mountPoint, sources); err != nil {
+		t.Fatalf("SetSource() error = %v", err)
+	}
+
+	got, err := GetSource(mountPoint)
+	if err != nil {
+		t.Fatalf("GetSource() after SetSource() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, sources) {
+		t.Fatalf("GetSource() after SetSource() = %#v, want %#v", got, sources)
+	}
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -22,6 +22,15 @@ func Mount(source string, mountpoint string, fstype *string, options *string) er
 	return nil
 }
 
+// Bind mounts source at mountpoint without applying the filesystem-specific
+// validation used by the higher-level volume mount API. Bind targets are
+// intentionally allowed to contain files because the target is an existing
+// directory inside another mount (for example /DATA/AppData).
+func Bind(source string, mountpoint string) error {
+	options := "bind"
+	return Mount(source, mountpoint, nil, &options)
+}
+
 func UmountByMountPoint(mountpoint string) error {
 	if _, err := command.ExecuteCommand("umount", "--force", "--verbose", "--quiet", mountpoint); err != nil {
 		return err

--- a/route/v2/merge.go
+++ b/route/v2/merge.go
@@ -1,14 +1,9 @@
 package v2
 
 import (
-	"fmt"
-
 	"net/http"
-	"os"
 	"strings"
 
-	"github.com/IceWhaleTech/CasaOS-Common/utils/constants"
-	"github.com/IceWhaleTech/CasaOS-Common/utils/file"
 	"github.com/IceWhaleTech/CasaOS-Common/utils/logger"
 	"github.com/IceWhaleTech/CasaOS-LocalStorage/codegen"
 	"github.com/IceWhaleTech/CasaOS-LocalStorage/common"
@@ -48,6 +43,40 @@ func (s *LocalStorage) SetMerge(ctx echo.Context) error {
 	if err := ctx.Bind(&m); err != nil {
 		message := err.Error()
 		return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
+	}
+
+	// An explicitly empty source list is the full-unmerge operation for the
+	// default data root. This is deliberately different from an omitted source
+	// list, which leaves the current source selection unchanged.
+	if isFullMergeRemoval(m) {
+		if err := service.MyService.LocalStorage().RemoveMerge(m.MountPoint); err != nil {
+			message := err.Error()
+			logger.Error("failed to remove merge", zap.Error(err), zap.String("mount point", m.MountPoint))
+			return ctx.JSON(http.StatusInternalServerError, codegen.BaseResponse{Message: &message})
+		}
+
+		config.ServerInfo.EnableMergerFS = "false"
+		if config.Cfg != nil {
+			config.Cfg.Section("server").Key("EnableMergerFS").SetValue("false")
+			if err := config.Cfg.SaveTo(config.LocalStorageConfigFilePath); err != nil {
+				message := err.Error()
+				logger.Error("failed to persist mergerfs disabled state", zap.Error(err))
+				return ctx.JSON(http.StatusInternalServerError, codegen.BaseResponse{Message: &message})
+			}
+		}
+
+		const messageStatus = common.ServiceName + ":merge_status"
+		msg := map[string]interface{}{
+			"mount_point":         m.MountPoint,
+			"source_base_path":    "",
+			"source_volume_uuids": []string{},
+		}
+		if err := service.MyService.Notify().SendNotify(messageStatus, msg); err != nil {
+			logger.Error("error when sending merge removal notification", zap.Error(err), zap.String("message path", messageStatus), zap.Any("message", msg))
+		}
+
+		message := "merge removed"
+		return ctx.JSON(http.StatusOK, codegen.SetMergeResponseOK{Message: &message})
 	}
 
 	// default to mergerfs if fstype is not specified
@@ -92,11 +121,10 @@ func (s *LocalStorage) SetMerge(ctx echo.Context) error {
 
 	if merge == nil {
 		merge = &model2.Merge{
-			FSType:         fstype,
-			MountPoint:     m.MountPoint,
-			SourceBasePath: m.SourceBasePath,
-			SourceVolumes:  sourceVolumes,
+			FSType:     fstype,
+			MountPoint: m.MountPoint,
 		}
+		applyMergeSources(merge, m.SourceBasePath, m.SourceVolumeUuids, sourceVolumes)
 
 		if err := service.MyService.LocalStorage().CreateMerge(merge); err != nil {
 
@@ -111,13 +139,7 @@ func (s *LocalStorage) SetMerge(ctx echo.Context) error {
 			return ctx.JSON(http.StatusInternalServerError, codegen.BaseResponse{Message: &message})
 		}
 	} else {
-		if m.SourceBasePath != nil {
-			merge.SourceBasePath = m.SourceBasePath
-		}
-
-		if m.SourceVolumeUuids != nil {
-			merge.SourceVolumes = sourceVolumes // which come from m.SourceVolumeUuids
-		}
+		applyMergeSources(merge, m.SourceBasePath, m.SourceVolumeUuids, sourceVolumes)
 
 		if err := service.MyService.LocalStorage().UpdateMerge(merge); err != nil {
 			message := err.Error()
@@ -130,6 +152,11 @@ func (s *LocalStorage) SetMerge(ctx echo.Context) error {
 			logger.Error("failed to update merge sources in database", zap.Error(err), zap.String("mount point", m.MountPoint))
 			return ctx.JSON(http.StatusInternalServerError, codegen.BaseResponse{Message: &message})
 		}
+	}
+	if err := enableMergerFSConfig(); err != nil {
+		message := err.Error()
+		logger.Error("failed to persist mergerfs enabled state", zap.Error(err))
+		return ctx.JSON(http.StatusInternalServerError, codegen.BaseResponse{Message: &message})
 	}
 	const messageStatus = common.ServiceName + ":merge_status"
 	result := MergeAdapterOut(*merge)
@@ -149,6 +176,42 @@ func (s *LocalStorage) SetMerge(ctx echo.Context) error {
 		Data: &result,
 	})
 }
+
+func applyMergeSources(merge *model2.Merge, sourceBasePath *string, sourceVolumeUuids *[]string, sourceVolumes []*model2.Volume) {
+	if sourceBasePath != nil {
+		if strings.TrimSpace(*sourceBasePath) == "" {
+			merge.SourceBasePath = nil
+		} else {
+			merge.SourceBasePath = sourceBasePath
+		}
+	} else if sourceVolumeUuids != nil {
+		// An explicit volume list represents the complete source selection. Do
+		// not retain the system-storage bootstrap path unless it is requested.
+		merge.SourceBasePath = nil
+	}
+
+	if sourceVolumeUuids != nil {
+		merge.SourceVolumes = sourceVolumes
+	}
+}
+
+func isFullMergeRemoval(merge codegen.Merge) bool {
+	if merge.MountPoint != common.DefaultMountPoint || merge.SourceVolumeUuids == nil || len(*merge.SourceVolumeUuids) != 0 {
+		return false
+	}
+	return merge.SourceBasePath == nil || strings.TrimSpace(*merge.SourceBasePath) == ""
+}
+
+func enableMergerFSConfig() error {
+	config.ServerInfo.EnableMergerFS = "true"
+	if config.Cfg == nil {
+		return nil
+	}
+
+	config.Cfg.Section("server").Key("EnableMergerFS").SetValue("true")
+	return config.Cfg.SaveTo(config.LocalStorageConfigFilePath)
+}
+
 func (s *LocalStorage) GetMergeInitStatus(ctx echo.Context) error {
 	status := codegen.Uninitialized
 	mountPoint := common.DefaultMountPoint
@@ -178,27 +241,8 @@ func (s *LocalStorage) InitMerge(ctx echo.Context) error {
 		return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
 	}
 	if strings.ToLower(config.ServerInfo.EnableMergerFS) != "true" {
-		if !file.CheckNotExist(m.MountPoint) {
-
-			dir, _ := os.ReadDir(constants.DefaultFilePath)
-			if len(dir) > 0 {
-				message := "Please make sure the /var/lib/casaos/files directory is empty"
-				return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
-			}
-
-			file.RMDir(constants.DefaultFilePath)
-
-			err := os.Rename(m.MountPoint, constants.DefaultFilePath)
-			if err != nil {
-				fmt.Println(err)
-				message := "move " + m.MountPoint + " to /var/lib/casaos/files failed"
-				return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
-			}
-		}
-		err := file.MkDir(m.MountPoint)
-		if err != nil {
-			fmt.Println(err)
-			message := "create " + m.MountPoint + " failed"
+		if err := service.MyService.LocalStorage().PrepareExternalDataRoot(m.MountPoint); err != nil {
+			message := err.Error()
 			return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
 		}
 
@@ -208,18 +252,9 @@ func (s *LocalStorage) InitMerge(ctx echo.Context) error {
 			return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
 		}
 
-		if !service.MyService.Disk().EnsureDefaultMergePoint() {
-			config.ServerInfo.EnableMergerFS = "false"
-			message := "default merge point is not empty"
-			return ctx.JSON(http.StatusBadRequest, codegen.ResponseBadRequest{Message: &message})
-		}
-
-		service.MyService.LocalStorage().CheckMergeMount()
-
-		config.Cfg.Section("server").Key("EnableMergerFS").SetValue("true")
-		config.ServerInfo.EnableMergerFS = "true"
-
-		config.Cfg.SaveTo(config.LocalStorageConfigFilePath)
+		// The actual mergerfs mount is created by SetMerge from the selected
+		// external volumes. Do not create the historical system-backed bootstrap
+		// merge here, otherwise the flash/system disk is briefly part of /DATA.
 	} else {
 		status := codegen.Initialized
 		return ctx.JSON(http.StatusOK, codegen.InitMergeResponseOK{Data: &status})

--- a/route/v2/merge_test.go
+++ b/route/v2/merge_test.go
@@ -1,0 +1,67 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/codegen"
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/common"
+	model2 "github.com/IceWhaleTech/CasaOS-LocalStorage/service/model"
+)
+
+func TestApplyMergeSourcesClearsBootstrapPathForExplicitVolumes(t *testing.T) {
+	basePath := "/var/lib/casaos/files"
+	volumeUUIDs := []string{"data-volume"}
+	volumes := []*model2.Volume{{UUID: "data-volume", MountPoint: "/mnt/data"}}
+	merge := &model2.Merge{SourceBasePath: &basePath}
+
+	applyMergeSources(merge, nil, &volumeUUIDs, volumes)
+
+	if merge.SourceBasePath != nil {
+		t.Fatalf("expected bootstrap source path to be cleared, got %q", *merge.SourceBasePath)
+	}
+	if len(merge.SourceVolumes) != 1 || merge.SourceVolumes[0] != volumes[0] {
+		t.Fatalf("expected explicit source volumes to be applied, got %#v", merge.SourceVolumes)
+	}
+}
+
+func TestApplyMergeSourcesKeepsExplicitBasePath(t *testing.T) {
+	basePath := "/mnt/system-data"
+	volumeUUIDs := []string{"data-volume"}
+	volumes := []*model2.Volume{{UUID: "data-volume", MountPoint: "/mnt/data"}}
+	merge := &model2.Merge{}
+
+	applyMergeSources(merge, &basePath, &volumeUUIDs, volumes)
+
+	if merge.SourceBasePath == nil || *merge.SourceBasePath != basePath {
+		t.Fatalf("expected explicit base path %q, got %#v", basePath, merge.SourceBasePath)
+	}
+}
+
+func TestApplyMergeSourcesNormalizesEmptyBasePath(t *testing.T) {
+	basePath := ""
+	volumeUUIDs := []string{"data-volume"}
+	volumes := []*model2.Volume{{UUID: "data-volume", MountPoint: "/mnt/data"}}
+	merge := &model2.Merge{}
+
+	applyMergeSources(merge, &basePath, &volumeUUIDs, volumes)
+
+	if merge.SourceBasePath != nil {
+		t.Fatalf("expected an empty base path to be normalized away, got %q", *merge.SourceBasePath)
+	}
+}
+
+func TestIsFullMergeRemovalRequiresExplicitEmptySelection(t *testing.T) {
+	emptySources := []string{}
+	basePath := ""
+	if !isFullMergeRemoval(codegen.Merge{
+		MountPoint:        common.DefaultMountPoint,
+		SourceBasePath:    &basePath,
+		SourceVolumeUuids: &emptySources,
+	}) {
+		t.Fatal("expected an explicit empty source selection to request a full unmerge")
+	}
+
+	if isFullMergeRemoval(codegen.Merge{MountPoint: common.DefaultMountPoint}) {
+		t.Fatal("expected an omitted source selection not to request a full unmerge")
+	}
+}

--- a/service/disk.go
+++ b/service/disk.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	command2 "github.com/IceWhaleTech/CasaOS-Common/utils/command"
-	"github.com/IceWhaleTech/CasaOS-Common/utils/constants"
 	"github.com/IceWhaleTech/CasaOS-Common/utils/exec"
 	"github.com/IceWhaleTech/CasaOS-Common/utils/file"
 	"github.com/IceWhaleTech/CasaOS-Common/utils/logger"
@@ -29,8 +28,6 @@ import (
 	"github.com/IceWhaleTech/CasaOS-LocalStorage/pkg/partition"
 	"github.com/IceWhaleTech/CasaOS-LocalStorage/pkg/utils/command"
 	model2 "github.com/IceWhaleTech/CasaOS-LocalStorage/service/model"
-	v2 "github.com/IceWhaleTech/CasaOS-LocalStorage/service/v2"
-	"github.com/IceWhaleTech/CasaOS-LocalStorage/service/v2/fs"
 	jsoniter "github.com/json-iterator/go"
 	"github.com/moby/sys/mountinfo"
 	"go.uber.org/zap"
@@ -78,7 +75,6 @@ var (
 
 func (d *diskService) EnsureDefaultMergePoint() bool {
 	mountPoint := common.DefaultMountPoint
-	sourceBasePath := constants.DefaultFilePath
 
 	existingMerges, err := MyService.LocalStorage().GetMergeAllFromDB(&mountPoint)
 	if err != nil {
@@ -94,54 +90,17 @@ func (d *diskService) EnsureDefaultMergePoint() bool {
 		return true
 	}
 
-	merge := &model2.Merge{
-		FSType:         fs.MergerFSFullName,
-		MountPoint:     mountPoint,
-		SourceBasePath: &sourceBasePath,
-	}
-	if err := MyService.LocalStorage().CreateMerge(merge); err != nil {
-		if errors.Is(err, v2.ErrMergeMountPointAlreadyExists) {
-			logger.Info(err.Error(), zap.String("mount point", mountPoint))
-		} else if errors.Is(err, v2.ErrMountPointIsNotEmpty) {
-			logger.Error("Mount point "+mountPoint+" is not empty", zap.String("mount point", mountPoint))
+	// Do not create the historical system-backed merge when there is no
+	// configured pool. The first external-only merge must be initialized by
+	// the API after the user selects its source volumes.
+	config.ServerInfo.EnableMergerFS = "false"
+	if config.Cfg != nil {
+		config.Cfg.Section("server").Key("EnableMergerFS").SetValue("false")
+		if err := config.Cfg.SaveTo(config.LocalStorageConfigFilePath); err != nil {
+			logger.Error("failed to persist disabled mergerfs state", zap.Error(err))
 			return false
-		} else {
-			panic(err)
 		}
 	}
-
-	// mounts, err := MyService.LocalStorage().GetMounts(codegen.GetMountsParams{})
-	// if err != nil {
-	// 	logger.Error("failed to get mount list from system", zap.Error(err))
-	// 	return false
-	// }
-	// isExist := false
-	// for _, v := range mounts {
-	// 	if v.MountPoint == mountPoint {
-	// 		config.ServerInfo.EnableMergerFS = "true"
-	// 		isExist = true
-	// 		merge.SourceBasePath = v.Source
-	// 		break
-	// 	}
-	// }
-
-	// if !isExist {
-	// 	if err := MyService.LocalStorage().CreateMerge(merge); err != nil {
-	// 		if errors.Is(err, v2.ErrMergeMountPointAlreadyExists) {
-	// 			logger.Info(err.Error(), zap.String("mount point", mountPoint))
-	// 		} else if errors.Is(err, v2.ErrMountPointIsNotEmpty) {
-	// 			logger.Error("Mount point "+mountPoint+" is not empty", zap.String("mount point", mountPoint))
-	// 			return false
-	// 		} else {
-	// 			panic(err)
-	// 		}
-	// 	}
-	// }
-
-	if err := MyService.LocalStorage().CreateMergeInDB(merge); err != nil {
-		panic(err)
-	}
-	config.ServerInfo.EnableMergerFS = "true"
 	return true
 }
 

--- a/service/v2/data_layout.go
+++ b/service/v2/data_layout.go
@@ -1,0 +1,373 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/IceWhaleTech/CasaOS-Common/utils/constants"
+	"github.com/IceWhaleTech/CasaOS-Common/utils/file"
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/codegen"
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/common"
+	mountpkg "github.com/IceWhaleTech/CasaOS-LocalStorage/pkg/mount"
+	model2 "github.com/IceWhaleTech/CasaOS-LocalStorage/service/model"
+	"github.com/moby/sys/mountinfo"
+)
+
+const appDataDirectory = "AppData"
+
+var (
+	ErrDataMountPointConflict = errors.New("/DATA/AppData is already mounted from an unexpected source")
+	ErrDataMountPointNotEmpty = errors.New("/DATA contains data that cannot be safely restored")
+)
+
+func usesExternalDataBranches(merge *model2.Merge) bool {
+	if merge == nil || merge.MountPoint != common.DefaultMountPoint || len(merge.SourceVolumes) == 0 {
+		return false
+	}
+
+	return merge.SourceBasePath == nil || strings.TrimSpace(*merge.SourceBasePath) == ""
+}
+
+func systemAppDataPath() string {
+	return filepath.Join(constants.DefaultFilePath, appDataDirectory)
+}
+
+func dataAppDataMountPoint() string {
+	return filepath.Join(common.DefaultMountPoint, appDataDirectory)
+}
+
+func (s *LocalStorageService) rawMountsAt(mountPoint string) ([]*mountinfo.Info, error) {
+	if s._mountinfo == nil {
+		return nil, errors.New("mount information is unavailable")
+	}
+	return s._mountinfo.GetMounts(func(info *mountinfo.Info) (skip bool, stop bool) {
+		return info.Mountpoint != mountPoint, false
+	})
+}
+
+func isBindSource(info *mountinfo.Info, source string) bool {
+	return filepath.Clean(info.Source) == filepath.Clean(source) || filepath.Clean(info.Root) == filepath.Clean(source)
+}
+
+func isExpectedAppDataMount(info *mountinfo.Info, source string, target string) bool {
+	if isBindSource(info, source) {
+		return true
+	}
+
+	sourceInfo, sourceErr := os.Stat(source)
+	targetInfo, targetErr := os.Stat(target)
+	return sourceErr == nil && targetErr == nil && os.SameFile(sourceInfo, targetInfo)
+}
+
+// ensureAppDataCompatibilityMount keeps the directory expected by CasaOS
+// applications backed by the original system-data tree. A bind mount is used
+// instead of a symlink because Docker bind mounts must expose the real
+// directory tree to containers.
+func (s *LocalStorageService) ensureAppDataCompatibilityMount(merge *model2.Merge) error {
+	if !usesExternalDataBranches(merge) {
+		return nil
+	}
+
+	source := systemAppDataPath()
+	target := dataAppDataMountPoint()
+	if err := ensureDirectory(source); err != nil {
+		return fmt.Errorf("create system AppData directory: %w", err)
+	}
+	if err := ensureDirectory(target); err != nil {
+		return fmt.Errorf("create /DATA/AppData directory: %w", err)
+	}
+
+	mounts, err := s.rawMountsAt(target)
+	if err != nil {
+		return err
+	}
+	if len(mounts) > 0 {
+		for _, mounted := range mounts {
+			if isExpectedAppDataMount(mounted, source, target) {
+				return nil
+			}
+		}
+		return ErrDataMountPointConflict
+	}
+
+	if err := mountpkg.Bind(source, target); err != nil {
+		return fmt.Errorf("bind %s to %s: %w", source, target, err)
+	}
+	return nil
+}
+
+func (s *LocalStorageService) unmountIfPresent(mountPoint string) error {
+	mounts, err := s.GetMounts(codegen.GetMountsParams{MountPoint: &mountPoint})
+	if err != nil {
+		return err
+	}
+	if len(mounts) == 0 {
+		return nil
+	}
+	if err := mountpkg.UmountByMountPoint(mountPoint); err != nil {
+		return fmt.Errorf("unmount %s: %w", mountPoint, err)
+	}
+	return nil
+}
+
+func (s *LocalStorageService) unmountAppDataCompatibilityMount() error {
+	source := systemAppDataPath()
+	target := dataAppDataMountPoint()
+	mounts, err := s.rawMountsAt(target)
+	if err != nil {
+		return err
+	}
+	if len(mounts) == 0 {
+		return nil
+	}
+
+	for _, mounted := range mounts {
+		if !isExpectedAppDataMount(mounted, source, target) {
+			return ErrDataMountPointConflict
+		}
+	}
+	return s.unmountIfPresent(target)
+}
+
+func (s *LocalStorageService) unmountMergeIfPresent(merge *model2.Merge) error {
+	mounts, err := s.GetMounts(codegen.GetMountsParams{MountPoint: &merge.MountPoint})
+	if err != nil {
+		return err
+	}
+	if len(mounts) == 0 {
+		return nil
+	}
+
+	for _, mounted := range mounts {
+		if mounted.Fstype == nil ||
+			(*mounted.Fstype != merge.FSType && *mounted.Fstype != "mergerfs" && *mounted.Fstype != "fuse.mergerfs") {
+			return fmt.Errorf("refusing to unmount %s: it is not the configured mergerfs mount", merge.MountPoint)
+		}
+	}
+
+	if err := mountpkg.UmountByMountPoint(merge.MountPoint); err != nil {
+		return fmt.Errorf("unmount mergerfs at %s: %w", merge.MountPoint, err)
+	}
+	return nil
+}
+
+func ensureDirectory(path string) error {
+	if err := file.IsNotExistMkDir(path); err != nil {
+		return err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", path)
+	}
+	return nil
+}
+
+// PrepareExternalDataRoot separates the system-data tree from the /DATA
+// mountpoint before an external-only merge is created. Existing content is
+// moved into the system-data tree without overwriting collisions. A symlink
+// from /DATA to the system-data tree is replaced with an empty directory,
+// leaving the target tree (including AppData) in place.
+func (s *LocalStorageService) PrepareExternalDataRoot(mountPoint string) error {
+	if mountPoint != common.DefaultMountPoint {
+		return fmt.Errorf("external data root preparation only supports %s", common.DefaultMountPoint)
+	}
+	return prepareDataRoots(constants.DefaultFilePath, mountPoint)
+}
+
+func prepareDataRoots(systemRoot string, dataRoot string) error {
+	if filepath.Clean(systemRoot) == filepath.Clean(dataRoot) {
+		return fmt.Errorf("system data root and data mountpoint must be different")
+	}
+
+	dataInfo, dataErr := os.Lstat(dataRoot)
+	if dataErr != nil && !os.IsNotExist(dataErr) {
+		return dataErr
+	}
+
+	systemInfo, systemErr := os.Lstat(systemRoot)
+	if systemErr != nil && !os.IsNotExist(systemErr) {
+		return systemErr
+	}
+
+	if dataErr == nil && dataInfo.Mode()&os.ModeSymlink != 0 {
+		resolvedDataRoot, err := filepath.EvalSymlinks(dataRoot)
+		if err != nil {
+			return fmt.Errorf("resolve %s: %w", dataRoot, err)
+		}
+		resolvedSystemRoot, err := filepath.EvalSymlinks(systemRoot)
+		if err != nil {
+			return fmt.Errorf("resolve %s: %w", systemRoot, err)
+		}
+		if filepath.Clean(resolvedDataRoot) != filepath.Clean(resolvedSystemRoot) {
+			return fmt.Errorf("refusing to replace %s: it points to %s", dataRoot, resolvedDataRoot)
+		}
+		if err := os.Remove(dataRoot); err != nil {
+			return fmt.Errorf("remove %s symlink: %w", dataRoot, err)
+		}
+		return ensureDirectory(dataRoot)
+	}
+
+	if dataErr != nil {
+		if systemErr == nil {
+			return ensureDirectory(dataRoot)
+		}
+		if os.IsNotExist(systemErr) {
+			if err := ensureDirectory(systemRoot); err != nil {
+				return err
+			}
+			return ensureDirectory(dataRoot)
+		}
+		if err := os.Rename(dataRoot, systemRoot); err != nil {
+			return fmt.Errorf("move %s to %s: %w", dataRoot, systemRoot, err)
+		}
+		return ensureDirectory(dataRoot)
+	}
+
+	if !dataInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", dataRoot)
+	}
+	if systemErr == nil && !systemInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", systemRoot)
+	}
+	if systemErr != nil {
+		if err := os.Rename(dataRoot, systemRoot); err != nil {
+			return fmt.Errorf("move %s to %s: %w", dataRoot, systemRoot, err)
+		}
+		return ensureDirectory(dataRoot)
+	}
+
+	dataStat, err := os.Stat(dataRoot)
+	if err != nil {
+		return err
+	}
+	systemStat, err := os.Stat(systemRoot)
+	if err != nil {
+		return err
+	}
+	if os.SameFile(dataStat, systemStat) {
+		return fmt.Errorf("%s and %s refer to the same directory", dataRoot, systemRoot)
+	}
+
+	if err := moveDirectoryContents(dataRoot, systemRoot); err != nil {
+		return err
+	}
+	if err := os.Remove(dataRoot); err != nil {
+		return fmt.Errorf("remove empty %s: %w", dataRoot, err)
+	}
+	return ensureDirectory(dataRoot)
+}
+
+func moveDirectoryContents(sourceRoot string, targetRoot string) error {
+	entries, err := os.ReadDir(sourceRoot)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		sourcePath := filepath.Join(sourceRoot, entry.Name())
+		targetPath := filepath.Join(targetRoot, entry.Name())
+		targetInfo, targetErr := os.Lstat(targetPath)
+		if os.IsNotExist(targetErr) {
+			if err := os.Rename(sourcePath, targetPath); err != nil {
+				return fmt.Errorf("move %s to %s: %w", sourcePath, targetPath, err)
+			}
+			continue
+		}
+		if targetErr != nil {
+			return targetErr
+		}
+
+		sourceInfo, err := os.Lstat(sourcePath)
+		if err != nil {
+			return err
+		}
+		if sourceInfo.IsDir() && targetInfo.IsDir() {
+			if err := moveDirectoryContents(sourcePath, targetPath); err != nil {
+				return err
+			}
+			if err := os.Remove(sourcePath); err != nil {
+				return fmt.Errorf("remove merged source directory %s: %w", sourcePath, err)
+			}
+			continue
+		}
+		return fmt.Errorf("refusing to overwrite existing data path %s", targetPath)
+	}
+	return nil
+}
+
+// restoreSystemDataRoot reverses the InitMerge directory move. It only
+// removes an empty mountpoint directory, so files written while the mergerfs
+// mount was active are never deleted by an unmerge operation.
+func restoreSystemDataRoot() error {
+	systemRoot := constants.DefaultFilePath
+	dataRoot := common.DefaultMountPoint
+
+	systemInfo, err := os.Stat(systemRoot)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		return ensureDirectory(dataRoot)
+	}
+	if !systemInfo.IsDir() {
+		return fmt.Errorf("%s is not a directory", systemRoot)
+	}
+
+	dataInfo, err := os.Stat(dataRoot)
+	if err == nil {
+		if !dataInfo.IsDir() {
+			return fmt.Errorf("%s is not a directory", dataRoot)
+		}
+		entries, readErr := os.ReadDir(dataRoot)
+		if readErr != nil {
+			return readErr
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("%w: %s is not empty", ErrDataMountPointNotEmpty, dataRoot)
+		}
+		if err := os.Remove(dataRoot); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if err := os.Rename(systemRoot, dataRoot); err != nil {
+		return fmt.Errorf("restore %s to %s: %w", systemRoot, dataRoot, err)
+	}
+	return nil
+}
+
+// RemoveMerge performs a full unmerge for the default CasaOS data root. It
+// detaches the compatibility mount first, leaves every external disk mounted,
+// restores the original system-data directory, and only then removes the
+// merge record from the database.
+func (s *LocalStorageService) RemoveMerge(mountPoint string) error {
+	merge, err := s.GetFirstMergeFromDB(mountPoint)
+	if err != nil {
+		return err
+	}
+	if merge == nil {
+		return ErrMergeMountPointDoesNotExist
+	}
+
+	if mountPoint == common.DefaultMountPoint {
+		if err := s.unmountAppDataCompatibilityMount(); err != nil {
+			return err
+		}
+	}
+	if err := s.unmountMergeIfPresent(merge); err != nil {
+		return err
+	}
+	if mountPoint == common.DefaultMountPoint {
+		if err := restoreSystemDataRoot(); err != nil {
+			return err
+		}
+	}
+	return s.DeleteMergeFromDB(merge)
+}

--- a/service/v2/data_layout_test.go
+++ b/service/v2/data_layout_test.go
@@ -1,0 +1,128 @@
+package v2
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/common"
+	model2 "github.com/IceWhaleTech/CasaOS-LocalStorage/service/model"
+	"github.com/moby/sys/mountinfo"
+)
+
+func TestUsesExternalDataBranches(t *testing.T) {
+	volume := &model2.Volume{UUID: "data-volume", MountPoint: "/mnt/data"}
+
+	if !usesExternalDataBranches(&model2.Merge{
+		MountPoint:     common.DefaultMountPoint,
+		SourceVolumes:  []*model2.Volume{volume},
+		SourceBasePath: nil,
+	}) {
+		t.Fatal("expected a merge with external volumes and no base path to use external branches")
+	}
+
+	basePath := "/var/lib/casaos/files"
+	if usesExternalDataBranches(&model2.Merge{
+		MountPoint:     common.DefaultMountPoint,
+		SourceVolumes:  []*model2.Volume{volume},
+		SourceBasePath: &basePath,
+	}) {
+		t.Fatal("expected a merge with a system base path to retain the system branch")
+	}
+
+	if usesExternalDataBranches(&model2.Merge{MountPoint: common.DefaultMountPoint}) {
+		t.Fatal("expected a merge with no source volumes not to use external branches")
+	}
+}
+
+func TestIsBindSourceMatchesMountRoot(t *testing.T) {
+	info := &mountinfo.Info{Source: "/dev/sda1", Root: "/var/lib/casaos/files/AppData"}
+	if !isBindSource(info, "/var/lib/casaos/files/AppData") {
+		t.Fatal("expected the bind source to match the mount root")
+	}
+}
+
+func TestPrepareDataRootsPreservesExistingSystemData(t *testing.T) {
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "files")
+	dataRoot := filepath.Join(root, "DATA")
+	if err := os.MkdirAll(filepath.Join(systemRoot, "AppData"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(dataRoot, "Documents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(systemRoot, "AppData", "settings.json"), []byte("system"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataRoot, "Documents", "readme.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareDataRoots(systemRoot, dataRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(systemRoot, "AppData", "settings.json")); err != nil {
+		t.Fatalf("system AppData was not preserved: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(systemRoot, "Documents", "readme.txt")); err != nil {
+		t.Fatalf("existing /DATA content was not moved: %v", err)
+	}
+	entries, err := os.ReadDir(dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected an empty data mountpoint, found %d entries", len(entries))
+	}
+}
+
+func TestPrepareDataRootsReplacesSystemDataSymlink(t *testing.T) {
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "files")
+	dataRoot := filepath.Join(root, "DATA")
+	if err := os.MkdirAll(systemRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(systemRoot, "AppData"), []byte("system"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(systemRoot, dataRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := prepareDataRoots(systemRoot, dataRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	dataInfo, err := os.Lstat(dataRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dataInfo.IsDir() || dataInfo.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("expected a real empty data directory, got mode %s", dataInfo.Mode())
+	}
+	if _, err := os.Stat(filepath.Join(systemRoot, "AppData")); err != nil {
+		t.Fatalf("system data was not preserved after replacing symlink: %v", err)
+	}
+}
+
+func TestPrepareDataRootsCreatesBothRootsWhenAbsent(t *testing.T) {
+	root := t.TempDir()
+	systemRoot := filepath.Join(root, "files")
+	dataRoot := filepath.Join(root, "DATA")
+
+	if err := prepareDataRoots(systemRoot, dataRoot); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{systemRoot, dataRoot} {
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("expected %s to exist: %v", path, err)
+		}
+		if !info.IsDir() {
+			t.Fatalf("expected %s to be a directory", path)
+		}
+	}
+}

--- a/service/v2/merge.go
+++ b/service/v2/merge.go
@@ -21,6 +21,7 @@ var (
 	ErrMergeMountPointAlreadyExists  = errors.New("merge mount point already exists")
 	ErrMergeMountPointDoesNotExist   = errors.New("merge mount point does not exist")
 	ErrMergeMountPointSourceConflict = errors.New("source mount point should not be a child path of the merge mount point")
+	ErrMergeHasNoSources             = errors.New("a merge must have at least one source")
 	ErrNilReference                  = errors.New("reference is nil")
 )
 
@@ -76,11 +77,9 @@ func (s *LocalStorageService) GetMerges(mountPoint *string) ([]model2.Merge, err
 	if err != nil {
 		return nil, err
 	}
-
-	for _, merge := range mergesFromDB {
-		merge.SourceVolumes = excludeVolumesWithWrongMountPointAndUUID(merge.SourceVolumes)
-	}
-
+	// Keep configured-but-currently-missing volumes in the response so the UI
+	// can warn about them and preserve them for automatic reattachment. Runtime
+	// mount operations filter unavailable volumes below.
 	return mergesFromDB, nil
 }
 
@@ -94,12 +93,17 @@ func (s *LocalStorageService) CreateMerge(merge *model2.Merge) error {
 		return err
 	}
 
-	merge.SourceVolumes = excludeVolumesWithWrongMountPointAndUUID(merge.SourceVolumes)
+	mountedSourceVolumes := excludeVolumesWithWrongMountPointAndUUID(merge.SourceVolumes)
+	mountMerge := *merge
+	mountMerge.SourceVolumes = mountedSourceVolumes
 
-	sources, err := buildSources(merge)
+	sources, err := buildSources(&mountMerge)
 	if err != nil {
 		logger.Error("failed to build sources", zap.Error(err))
 		return err
+	}
+	if len(sources) == 0 {
+		return ErrMergeHasNoSources
 	}
 
 	// check if the mount point is empty before creating a new mergerfs mount
@@ -121,6 +125,13 @@ func (s *LocalStorageService) CreateMerge(merge *model2.Merge) error {
 		logger.Error("failed to mount mergerfs", zap.Error(err), zap.String("mountPoint", merge.MountPoint), zap.String("source", source))
 		return err
 	}
+	if err := s.ensureAppDataCompatibilityMount(merge); err != nil {
+		logger.Error("failed to expose system AppData at /DATA/AppData", zap.Error(err), zap.String("mountPoint", merge.MountPoint))
+		if unmountErr := s.Umount(merge.MountPoint); unmountErr != nil && !errors.Is(unmountErr, ErrNotMounted) {
+			logger.Error("failed to roll back mergerfs mount after AppData setup failure", zap.Error(unmountErr), zap.String("mountPoint", merge.MountPoint))
+		}
+		return err
+	}
 
 	return nil
 }
@@ -135,12 +146,17 @@ func (s *LocalStorageService) UpdateMerge(merge *model2.Merge) error {
 		return ErrMergeMountPointDoesNotExist
 	}
 
-	merge.SourceVolumes = excludeVolumesWithWrongMountPointAndUUID(merge.SourceVolumes)
+	mountedSourceVolumes := excludeVolumesWithWrongMountPointAndUUID(merge.SourceVolumes)
+	mountMerge := *merge
+	mountMerge.SourceVolumes = mountedSourceVolumes
 
-	sources, err := buildSources(merge)
+	sources, err := buildSources(&mountMerge)
 	if err != nil {
 		logger.Error("failed to build sources", zap.Error(err))
 		return err
+	}
+	if len(sources) == 0 {
+		return ErrMergeHasNoSources
 	}
 
 	// if it is already a merge point, check if the mount point is a mergerfs mount with the same sources
@@ -150,12 +166,22 @@ func (s *LocalStorageService) UpdateMerge(merge *model2.Merge) error {
 		return err
 	}
 
-	if !utils.CompareStringSlices(sources, existingSources) {
+	sourcesChanged := !utils.CompareStringSlices(sources, existingSources)
+	if sourcesChanged {
 		// update the mergerfs sources if different sources
 		if err := mergerfs.SetSource(merge.MountPoint, sources); err != nil {
 			logger.Error("failed to set mergerfs sources", zap.Error(err), zap.String("mountPoint", merge.MountPoint), zap.Any("sources", sources))
 			return err
 		}
+	}
+	if err := s.ensureAppDataCompatibilityMount(merge); err != nil {
+		logger.Error("failed to expose system AppData at /DATA/AppData", zap.Error(err), zap.String("mountPoint", merge.MountPoint))
+		if sourcesChanged {
+			if rollbackErr := mergerfs.SetSource(merge.MountPoint, existingSources); rollbackErr != nil {
+				logger.Error("failed to roll back mergerfs sources after AppData setup failure", zap.Error(rollbackErr), zap.String("mountPoint", merge.MountPoint))
+			}
+		}
+		return err
 	}
 
 	return nil

--- a/service/v2/merge_db.go
+++ b/service/v2/merge_db.go
@@ -66,3 +66,14 @@ func (s *LocalStorageService) CreateMergeInDB(merge *model2.Merge) error {
 	}
 	return nil
 }
+
+func (s *LocalStorageService) DeleteMergeFromDB(merge *model2.Merge) error {
+	if merge == nil {
+		return nil
+	}
+
+	if err := s._db.Model(merge).Association(model2.MergeSourceVolumes).Clear(); err != nil {
+		return err
+	}
+	return s._db.Delete(merge).Error
+}


### PR DESCRIPTION
## Summary

- Keep the system/flash storage out of the external-only `/DATA` mergerfs branches.
- Preserve the system-data tree and expose `/var/lib/casaos/files/AppData` at `/DATA/AppData` with a compatibility bind mount.
- Preserve configured-but-disconnected source volumes in the database/API response, while excluding unavailable volumes from runtime mount sources.
- Support explicit full unmerge of `/DATA` without deleting external disk data, and prevent startup/initialization from recreating a system-backed merge.

## Verification

- `GOOS=linux GOARCH=amd64 go test -c ./route/v2`
- `GOOS=linux GOARCH=amd64 go test -c ./service/v2`
- `GOOS=linux GOARCH=amd64 go vet ./...`
- `GOOS=linux GOARCH=amd64 go build ./...`
- `git diff --check`
