### PR TITLE
fix: deduplicate shared RAID storage enumeration

### DIFF
--- a/misc.go
+++ b/misc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"time"
 
@@ -18,31 +17,13 @@ import (
 
 func sendDiskBySocket() {
 	blkList := service.MyService.Disk().LSBLK(true)
-
-	status := model.DiskStatus{}
+	disks := []model.LSBLKModel{}
 	healthy := true
-
-	//var systemDisk *model.LSBLKModel
-
 	for _, currentDisk := range blkList {
-
-		// if systemDisk == nil {
-		// 	// go 5 level deep to look for system block device by mount point being "/"
-		// 	systemDisk = service.WalkDisk(currentDisk, 5, func(blk model.LSBLKModel) bool { return blk.MountPoint == "/" })
-
-		// 	if systemDisk != nil {
-		// 		s, _ := strconv.ParseUint(systemDisk.FSSize.String(), 10, 64)
-		// 		a, _ := strconv.ParseUint(systemDisk.FSAvail.String(), 10, 64)
-		// 		u, _ := strconv.ParseUint(systemDisk.FSUsed.String(), 10, 64)
-		// 		status.Size += s
-		// 		status.Avail += a
-		// 		status.Used += u
-		//		continue
-		// 	}
-		// }
 		if !service.IsDiskSupported(currentDisk) {
 			continue
 		}
+		disks = append(disks, currentDisk)
 		temp := service.MyService.Disk().SmartCTL(currentDisk.Path)
 		if reflect.DeepEqual(temp, model.SmartctlA{}) {
 			healthy = true
@@ -53,29 +34,8 @@ func sendDiskBySocket() {
 				healthy = true
 			}
 		}
-		if len(currentDisk.Children) > 0 {
-			for _, v := range currentDisk.Children {
-				if len(v.MountPoint) > 0 {
-					s, _ := strconv.ParseUint(v.FSSize.String(), 10, 64)
-					a, _ := strconv.ParseUint(v.FSAvail.String(), 10, 64)
-					u, _ := strconv.ParseUint(v.FSUsed.String(), 10, 64)
-					status.Size += s
-					status.Avail += a
-					status.Used += u
-				}
-			}
-		} else {
-			if len(currentDisk.MountPoint) > 0 {
-				s, _ := strconv.ParseUint(currentDisk.FSSize.String(), 10, 64)
-				a, _ := strconv.ParseUint(currentDisk.FSAvail.String(), 10, 64)
-				u, _ := strconv.ParseUint(currentDisk.FSUsed.String(), 10, 64)
-				status.Size += s
-				status.Avail += a
-				status.Used += u
-			}
-		}
 	}
-
+	status := model.StorageUsage(disks)
 	status.Health = healthy
 	message := make(map[string]interface{})
 	message["sys_disk"] = status

--- a/model/storage_devices.go
+++ b/model/storage_devices.go
@@ -1,0 +1,92 @@
+package model
+
+import (
+	"strconv"
+	"strings"
+)
+
+// StorageDevices builds a mounted-volume view without changing the lsblk graph
+// used by physical disk management. Shared RAID nodes may occur under every member.
+func StorageDevices(disks []LSBLKModel, systemPath string) []LSBLKModel {
+	result := make([]LSBLKModel, 0)
+	groups := make(map[string]int)
+	seen := make(map[[2]string]bool)
+	var visit func(LSBLKModel, LSBLKModel, string)
+	visit = func(node, owner LSBLKModel, groupKey string) {
+		if strings.HasPrefix(node.Type, "raid") && node.Path != "" {
+			owner = node
+			owner.Model = strings.ToUpper(node.Type)
+			owner.Tran = node.Type
+			groupKey = node.Path
+			if containsSystemStorage(node, systemPath) {
+				owner.Model = "System"
+			}
+		}
+		if node.MountPoint != "" && node.MountPoint != "[SWAP]" {
+			key := [2]string{node.Path, node.MountPoint}
+			if node.Path == "" || !seen[key] {
+				seen[key] = true
+				index, ok := groups[groupKey]
+				if !ok {
+					index = len(result)
+					groups[groupKey] = index
+					owner.Children = nil
+					owner.MountPoint = ""
+					result = append(result, owner)
+				}
+				volume := node
+				volume.Children = nil
+				result[index].Children = append(result[index].Children, volume)
+			}
+		}
+		for _, child := range node.Children {
+			visit(child, owner, groupKey)
+		}
+	}
+	for i, disk := range disks {
+		owner := disk
+		if containsSystemStorage(disk, systemPath) {
+			owner.Model = "System"
+		}
+		key := disk.Path
+		if key == "" {
+			key = strconv.Itoa(i)
+		}
+		visit(disk, owner, key)
+	}
+	return result
+}
+
+func containsSystemStorage(node LSBLKModel, systemPath string) bool {
+	if node.MountPoint == "/" || (systemPath != "" && node.Path == systemPath) {
+		return true
+	}
+	for _, child := range node.Children {
+		if containsSystemStorage(child, systemPath) {
+			return true
+		}
+	}
+	return false
+}
+
+// StorageUsage counts a filesystem once even when it has several mount points.
+// Health is populated separately from the physical drives' SMART reports.
+func StorageUsage(disks []LSBLKModel) DiskStatus {
+	status := DiskStatus{}
+	seen := make(map[string]bool)
+	for _, disk := range StorageDevices(disks, "") {
+		for _, volume := range disk.Children {
+			if volume.Path != "" && seen[volume.Path] {
+				continue
+			}
+			seen[volume.Path] = true
+			size, _ := strconv.ParseUint(volume.FSSize.String(), 10, 64)
+			avail, _ := strconv.ParseUint(volume.FSAvail.String(), 10, 64)
+			used, _ := strconv.ParseUint(volume.FSUsed.String(), 10, 64)
+			status.Size += size
+			status.Avail += avail
+			status.Used += used
+		}
+	}
+	return status
+}

--- a/model/storage_devices.go
+++ b/model/storage_devices.go
@@ -8,40 +8,11 @@ import (
 // StorageDevices builds a mounted-volume view without changing the lsblk graph
 // used by physical disk management. Shared RAID nodes may occur under every member.
 func StorageDevices(disks []LSBLKModel, systemPath string) []LSBLKModel {
-	result := make([]LSBLKModel, 0)
-	groups := make(map[string]int)
-	seen := make(map[[2]string]bool)
-	var visit func(LSBLKModel, LSBLKModel, string)
-	visit = func(node, owner LSBLKModel, groupKey string) {
-		if strings.HasPrefix(node.Type, "raid") && node.Path != "" {
-			owner = node
-			owner.Model = strings.ToUpper(node.Type)
-			owner.Tran = node.Type
-			groupKey = node.Path
-			if containsSystemStorage(node, systemPath) {
-				owner.Model = "System"
-			}
-		}
-		if node.MountPoint != "" && node.MountPoint != "[SWAP]" {
-			key := [2]string{node.Path, node.MountPoint}
-			if node.Path == "" || !seen[key] {
-				seen[key] = true
-				index, ok := groups[groupKey]
-				if !ok {
-					index = len(result)
-					groups[groupKey] = index
-					owner.Children = nil
-					owner.MountPoint = ""
-					result = append(result, owner)
-				}
-				volume := node
-				volume.Children = nil
-				result[index].Children = append(result[index].Children, volume)
-			}
-		}
-		for _, child := range node.Children {
-			visit(child, owner, groupKey)
-		}
+	view := storageDeviceView{
+		systemPath: systemPath,
+		devices:    make([]LSBLKModel, 0),
+		groups:     make(map[string]int),
+		seen:       make(map[[2]string]bool),
 	}
 	for i, disk := range disks {
 		owner := disk
@@ -52,9 +23,54 @@ func StorageDevices(disks []LSBLKModel, systemPath string) []LSBLKModel {
 		if key == "" {
 			key = strconv.Itoa(i)
 		}
-		visit(disk, owner, key)
+		view.visit(disk, owner, key)
 	}
-	return result
+	return view.devices
+}
+
+type storageDeviceView struct {
+	systemPath string
+	devices    []LSBLKModel
+	groups     map[string]int
+	seen       map[[2]string]bool
+}
+
+func (v *storageDeviceView) visit(node, owner LSBLKModel, groupKey string) {
+	if strings.HasPrefix(node.Type, "raid") && node.Path != "" {
+		owner = node
+		owner.Model = strings.ToUpper(node.Type)
+		owner.Tran = node.Type
+		groupKey = node.Path
+		if containsSystemStorage(node, v.systemPath) {
+			owner.Model = "System"
+		}
+	}
+	v.addMountedVolume(node, owner, groupKey)
+	for _, child := range node.Children {
+		v.visit(child, owner, groupKey)
+	}
+}
+
+func (v *storageDeviceView) addMountedVolume(node, owner LSBLKModel, groupKey string) {
+	if node.MountPoint == "" || node.MountPoint == "[SWAP]" {
+		return
+	}
+	key := [2]string{node.Path, node.MountPoint}
+	if node.Path != "" && v.seen[key] {
+		return
+	}
+	v.seen[key] = true
+	index, ok := v.groups[groupKey]
+	if !ok {
+		index = len(v.devices)
+		v.groups[groupKey] = index
+		owner.Children = nil
+		owner.MountPoint = ""
+		v.devices = append(v.devices, owner)
+	}
+	volume := node
+	volume.Children = nil
+	v.devices[index].Children = append(v.devices[index].Children, volume)
 }
 
 func containsSystemStorage(node LSBLKModel, systemPath string) bool {

--- a/model/storage_devices_test.go
+++ b/model/storage_devices_test.go
@@ -1,0 +1,135 @@
+package model
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func testVolume(path, mount string) LSBLKModel {
+	return LSBLKModel{Path: path, Name: path, MountPoint: mount, FsType: "ext4",
+		UUID: "same-label-is-not-identity", Label: "storage", FSSize: "1000", FSAvail: "800", FSUsed: "200"}
+}
+
+func testRAID(mount string, partitionedMembers bool) []LSBLKModel {
+	raid := testVolume("/dev/md0", mount)
+	raid.Type, raid.Size = "raid10", 2000
+	disks := []LSBLKModel{}
+	for _, path := range []string{"/dev/sda", "/dev/sdb", "/dev/sdc", "/dev/sdd"} {
+		member := LSBLKModel{Path: path, Type: "disk", Tran: "sata", Model: "HDD", Size: 1000, FsType: "linux_raid_member", Children: []LSBLKModel{raid}}
+		if partitionedMembers {
+			part := member
+			part.Path, part.Type = path+"1", "part"
+			member.FsType, member.Children = "", []LSBLKModel{part}
+		}
+		disks = append(disks, member)
+	}
+	return disks
+}
+
+func TestStorageDevicesRAID(t *testing.T) {
+	for _, partitioned := range []bool{false, true} {
+		for _, mount := range []string{"/mnt/storage", "/"} {
+			disks := testRAID(mount, partitioned)
+			before, _ := json.Marshal(disks)
+			got := StorageDevices(disks, "")
+			if len(got) != 1 || len(got[0].Children) != 1 {
+				t.Fatalf("partitioned=%v mount=%s: duplicate/missing volumes: %#v", partitioned, mount, got)
+			}
+			name := "RAID10"
+			if mount == "/" {
+				name = "System"
+			}
+			if got[0].Model != name || got[0].Path != "/dev/md0" || got[0].Size != 2000 || got[0].Tran != "raid10" {
+				t.Fatalf("wrong logical group: %#v", got[0])
+			}
+			if got[0].Children[0].MountPoint != mount {
+				t.Fatal("mount point changed")
+			}
+			if !reflect.DeepEqual(StorageDevices(got, ""), got) {
+				t.Fatal("not idempotent")
+			}
+			got[0].Children[0].Label = "changed"
+			after, _ := json.Marshal(disks)
+			if string(before) != string(after) {
+				t.Fatal("input tree changed")
+			}
+		}
+	}
+}
+
+func TestStorageDevicesSystemMembersAndDF(t *testing.T) {
+	disks := testRAID("/", false)
+	boot := testVolume("/dev/sda1", "/boot/efi")
+	disks[0].Children = append(disks[0].Children, boot)
+	got := StorageDevices(disks, "")
+	if len(got) != 2 || got[0].Model != "System" || got[1].Model != "System" {
+		t.Fatalf("root array or member boot partition lost protection: %#v", got)
+	}
+	disks = testRAID("/alternate-root", true)
+	got = StorageDevices(disks, "/dev/md0")
+	if got[0].Model != "System" {
+		t.Fatal("df system identity ignored")
+	}
+}
+
+func TestStorageDevicesPartitionsOnRAID(t *testing.T) {
+	data := testVolume("/dev/md0p1", "/mnt/first")
+	other := testVolume("/dev/md0p2", "/mnt/second")
+	raid := LSBLKModel{Path: "/dev/md0", Type: "raid1", Size: 2500, Children: []LSBLKModel{data, other}}
+	disks := []LSBLKModel{
+		{Path: "/dev/sda", Children: []LSBLKModel{raid}},
+		{Path: "/dev/sdb", Children: []LSBLKModel{raid}},
+	}
+	got := StorageDevices(disks, "")
+	if len(got) != 1 || len(got[0].Children) != 2 || got[0].Size != 2500 {
+		t.Fatalf("partitioned RAID not represented once: %#v", got)
+	}
+	if usage := StorageUsage(disks); usage.Size != 2000 || usage.Avail != 1600 || usage.Used != 400 {
+		t.Fatalf("wrong partitioned RAID totals: %#v", usage)
+	}
+}
+
+func TestStorageDevicesOrdinaryAndMissingMounts(t *testing.T) {
+	root := testVolume("/dev/mmcblk0p2", "/")
+	boot := testVolume("/dev/mmcblk0p1", "/boot/firmware")
+	usb := testVolume("/dev/sde", "/media/usb")
+	usb.Tran = "usb"
+	other := testVolume("/dev/sdf1", "/mnt/other")
+	disks := []LSBLKModel{
+		{Path: "/dev/mmcblk0", Children: []LSBLKModel{boot, root}}, usb,
+		{Path: "/dev/sdf", Children: []LSBLKModel{other}},
+		{Path: "/dev/sdg", FsType: "linux_raid_member"},
+		{Path: "/dev/zram0", MountPoint: "[SWAP]", FsType: "swap"},
+	}
+	got := StorageDevices(disks, "")
+	if len(got) != 3 || len(got[0].Children) != 2 || got[0].Model != "System" || got[1].Tran != "usb" {
+		t.Fatalf("ordinary volumes changed or unmounted volume exposed: %#v", got)
+	}
+	if got[1].Children[0].Path == got[2].Children[0].Path {
+		t.Fatal("same UUID/label disks merged")
+	}
+	if len(StorageDevices(nil, "")) != 0 {
+		t.Fatal("empty input")
+	}
+}
+
+func TestStorageUsageMultipleMountsAndArrays(t *testing.T) {
+	disks := testRAID("/mnt/storage", true)
+	bind := testVolume("/dev/md0", "/mnt/bind")
+	second := testVolume("/dev/md1", "/mnt/second")
+	second.Type, second.Size = "raid1", 1100
+	disks[0].Children = append(disks[0].Children, bind, second)
+	disks[1].Children = append(disks[1].Children, second)
+	got := StorageDevices(disks, "")
+	count := 0
+	for _, d := range got {
+		count += len(d.Children)
+	}
+	if count != 3 {
+		t.Fatalf("mounts lost or duplicated: %d", count)
+	}
+	if usage := StorageUsage(disks); usage.Size != 2000 || usage.Avail != 1600 || usage.Used != 400 {
+		t.Fatalf("multiple mounts counted more than once: %#v", usage)
+	}
+}

--- a/model/storage_devices_test.go
+++ b/model/storage_devices_test.go
@@ -28,33 +28,45 @@ func testRAID(mount string, partitionedMembers bool) []LSBLKModel {
 }
 
 func TestStorageDevicesRAID(t *testing.T) {
-	for _, partitioned := range []bool{false, true} {
-		for _, mount := range []string{"/mnt/storage", "/"} {
-			disks := testRAID(mount, partitioned)
-			before, _ := json.Marshal(disks)
-			got := StorageDevices(disks, "")
-			if len(got) != 1 || len(got[0].Children) != 1 {
-				t.Fatalf("partitioned=%v mount=%s: duplicate/missing volumes: %#v", partitioned, mount, got)
-			}
-			name := "RAID10"
-			if mount == "/" {
-				name = "System"
-			}
-			if got[0].Model != name || got[0].Path != "/dev/md0" || got[0].Size != 2000 || got[0].Tran != "raid10" {
-				t.Fatalf("wrong logical group: %#v", got[0])
-			}
-			if got[0].Children[0].MountPoint != mount {
-				t.Fatal("mount point changed")
-			}
-			if !reflect.DeepEqual(StorageDevices(got, ""), got) {
-				t.Fatal("not idempotent")
-			}
-			got[0].Children[0].Label = "changed"
-			after, _ := json.Marshal(disks)
-			if string(before) != string(after) {
-				t.Fatal("input tree changed")
-			}
-		}
+	cases := []struct {
+		name        string
+		mount       string
+		partitioned bool
+		model       string
+	}{
+		{"whole-drive data", "/mnt/storage", false, "RAID10"},
+		{"whole-drive root", "/", false, "System"},
+		{"partitioned data", "/mnt/storage", true, "RAID10"},
+		{"partitioned root", "/", true, "System"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			checkRAIDStorage(t, tc.mount, tc.partitioned, tc.model)
+		})
+	}
+}
+
+func checkRAIDStorage(t *testing.T, mount string, partitioned bool, name string) {
+	t.Helper()
+	disks := testRAID(mount, partitioned)
+	before, _ := json.Marshal(disks)
+	got := StorageDevices(disks, "")
+	if len(got) != 1 || len(got[0].Children) != 1 {
+		t.Fatalf("duplicate/missing volumes: %#v", got)
+	}
+	if got[0].Model != name || got[0].Path != "/dev/md0" || got[0].Size != 2000 || got[0].Tran != "raid10" {
+		t.Fatalf("wrong logical group: %#v", got[0])
+	}
+	if got[0].Children[0].MountPoint != mount {
+		t.Fatal("mount point changed")
+	}
+	if !reflect.DeepEqual(StorageDevices(got, ""), got) {
+		t.Fatal("not idempotent")
+	}
+	got[0].Children[0].Label = "changed"
+	after, _ := json.Marshal(disks)
+	if string(before) != string(after) {
+		t.Fatal("input tree changed")
 	}
 }
 

--- a/route/v1/disk.go
+++ b/route/v1/disk.go
@@ -19,6 +19,18 @@ import (
 
 const messagePathStorageStatus = common.ServiceName + ":storage_status"
 
+func diskInUse(disk model1.LSBLKModel) bool {
+	if disk.MountPoint != "" || disk.FsType == "linux_raid_member" || strings.HasPrefix(disk.Type, "raid") {
+		return true
+	}
+	for _, child := range disk.Children {
+		if diskInUse(child) {
+			return true
+		}
+	}
+	return false
+}
+
 var diskMap = make(map[string]string)
 
 type StorageMessage struct {
@@ -126,18 +138,7 @@ func GetDiskList(ctx echo.Context) error {
 			temp.SmartStatus.Passed = true
 		}
 
-		isAvail := true
-		if len(currentDisk.MountPoint) != 0 {
-			isAvail = false
-		} else {
-			for _, v := range currentDisk.Children {
-				if v.MountPoint != "" {
-					isAvail = false
-				}
-			}
-		}
-
-		if isAvail {
+		if !diskInUse(currentDisk) {
 			disk.NeedFormat = false
 			avail = append(avail, disk)
 		}

--- a/route/v1/storage.go
+++ b/route/v1/storage.go
@@ -12,7 +12,6 @@ package v1
 import (
 	"net/http"
 	"path/filepath"
-	"reflect"
 	"time"
 
 	"github.com/IceWhaleTech/CasaOS-Common/model"
@@ -28,120 +27,55 @@ import (
 )
 
 func GetStorageList(ctx echo.Context) error {
-	system := ctx.QueryParam("system")
-
+	showSystem := ctx.QueryParam("system") != ""
 	blkList := service.MyService.Disk().LSBLK(false)
-	foundSystem := false
-
-	storages := []model1.Storages{}
 	df, err := service.MyService.Disk().GetSystemDf()
-	// db, err := service.MyService.Disk().GetSerialAllFromDB()
-	// if err != nil {
-	// 	logger.Error("error when getting all volumes from database", zap.Error(err))
-	// 	return ctx.JSON(http.StatusInternalServerError, model.Result{Success: common_err.SERVICE_ERROR, Message: err.Error()})
-	// 	return
-	// }
-	// mapdb := make(map[string]string)
-	// for _, v := range db {
-	// 	mapdb[v.MountPoint] = v.MountPoint
-	// }
-	for _, currentDisk := range blkList {
-		// if currentDisk.Tran == "usb" {
-		// 	continue
-		// }
-
-		tempSystemDisk := false
-		children := 1
-		tempDisk := model1.Storages{
-			DiskName: currentDisk.Model,
-			Path:     currentDisk.Path,
-			Size:     currentDisk.Size,
-			Type:     currentDisk.Tran,
-		}
-
-		storageArr := []model1.Storage{}
-		temp := service.MyService.Disk().SmartCTL(currentDisk.Path)
-		if reflect.DeepEqual(temp, model1.SmartctlA{}) {
-			temp.SmartStatus.Passed = true
-		}
-		if len(currentDisk.Children) == 0 && service.IsDiskSupported(currentDisk) {
-			currentDisk.Children = append(currentDisk.Children, currentDisk)
-		}
-		for _, blkChild := range currentDisk.Children {
-			if err == nil {
-				if blkChild.Path == df.FileSystem {
-					tempDisk.DiskName = "System"
-					foundSystem = true
-					tempSystemDisk = true
-					logger.Info("found system disk", zap.String("disk", blkChild.Path))
-				}
-			}
-			if blkChild.MountPoint == "" {
-				continue
-			}
-			if !foundSystem {
-				if blkChild.MountPoint == "/" {
-					tempDisk.DiskName = "System"
-					foundSystem = true
-					tempSystemDisk = true
-				} else {
-					for _, c := range blkChild.Children {
-						if c.MountPoint == "/" {
-							tempDisk.DiskName = "System"
-							foundSystem = true
-							tempSystemDisk = true
-							break
-						}
-					}
-				}
-			}
-			stor := model1.Storage{
-				UUID:        blkChild.UUID,
-				MountPoint:  blkChild.MountPoint,
-				Size:        blkChild.FSSize.String(),
-				Avail:       blkChild.FSAvail.String(),
-				Used:        blkChild.FSUsed.String(),
-				Path:        blkChild.Path,
-				Type:        blkChild.FsType,
-				DriveName:   blkChild.Name,
-				PersistedIn: service.MyService.Disk().GetPersistentTypeByUUID(blkChild.UUID),
-			}
-			if len(blkChild.Label) == 0 {
-				if stor.MountPoint == "/" {
-					stor.Label = "System"
-				} else {
-					stor.Label = filepath.Base(stor.MountPoint)
-				}
-
-				children++
-			} else {
-				stor.Label = blkChild.Label
-			}
-			// if _, ok := mapdb[stor.MountPoint]; ok || stor.Label == "System" {
-			storageArr = append(storageArr, stor)
-			//}
-
-		}
-
-		if len(storageArr) == 0 {
-			continue
-		}
-
-		if tempSystemDisk && len(system) > 0 {
-			tempStorageArr := []model1.Storage{}
-			for i := 0; i < len(storageArr); i++ {
-				if storageArr[i].MountPoint != "/boot/efi" && storageArr[i].Type != "swap" {
-					tempStorageArr = append(tempStorageArr, storageArr[i])
-				}
-			}
-			tempDisk.Children = tempStorageArr
-			storages = append(storages, tempDisk)
-		} else if !tempSystemDisk {
-			tempDisk.Children = storageArr
-			storages = append(storages, tempDisk)
-		}
+	systemPath := ""
+	if err == nil {
+		systemPath = df.FileSystem
 	}
 
+	storages := []model1.Storages{}
+	for _, disk := range model1.StorageDevices(blkList, systemPath) {
+		isSystem := disk.Model == "System"
+		if isSystem && !showSystem {
+			continue
+		}
+		storage := model1.Storages{
+			DiskName: disk.Model,
+			Path:     disk.Path,
+			Size:     disk.Size,
+			Type:     disk.Tran,
+			Children: []model1.Storage{},
+		}
+		for _, volume := range disk.Children {
+			if isSystem && (volume.MountPoint == "/boot/efi" || volume.FsType == "swap") {
+				continue
+			}
+			label := volume.Label
+			if label == "" {
+				label = filepath.Base(volume.MountPoint)
+				if volume.MountPoint == "/" {
+					label = "System"
+				}
+			}
+			storage.Children = append(storage.Children, model1.Storage{
+				UUID:        volume.UUID,
+				MountPoint:  volume.MountPoint,
+				Size:        volume.FSSize.String(),
+				Avail:       volume.FSAvail.String(),
+				Used:        volume.FSUsed.String(),
+				Path:        volume.Path,
+				Type:        volume.FsType,
+				DriveName:   volume.Name,
+				Label:       label,
+				PersistedIn: service.MyService.Disk().GetPersistentTypeByUUID(volume.UUID),
+			})
+		}
+		if len(storage.Children) > 0 {
+			storages = append(storages, storage)
+		}
+	}
 	return ctx.JSON(common_err.SUCCESS, model.Result{Success: common_err.SUCCESS, Message: common_err.GetMsg(common_err.SUCCESS), Data: storages})
 }
 

--- a/route/v1/storage_test.go
+++ b/route/v1/storage_test.go
@@ -1,0 +1,185 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/model"
+	"github.com/IceWhaleTech/CasaOS-LocalStorage/service"
+	dbmodel "github.com/IceWhaleTech/CasaOS-LocalStorage/service/model"
+	"github.com/labstack/echo/v4"
+)
+
+type storageTestDisk struct {
+	service.DiskService
+	disks      []model.LSBLKModel
+	systemPath string
+	dfError    error
+	smartPaths []string
+}
+
+func (d *storageTestDisk) LSBLK(bool) []model.LSBLKModel { return d.disks }
+func (d *storageTestDisk) GetSystemDf() (model.DFDiskSpace, error) {
+	return model.DFDiskSpace{FileSystem: d.systemPath}, d.dfError
+}
+func (d *storageTestDisk) GetPersistentTypeByUUID(string) string         { return "fstab" }
+func (d *storageTestDisk) GetSerialAllFromDB() ([]dbmodel.Volume, error) { return nil, nil }
+func (d *storageTestDisk) SmartCTL(path string) model.SmartctlA {
+	d.smartPaths = append(d.smartPaths, path)
+	return model.SmartctlA{}
+}
+
+type storageTestServices struct {
+	service.Services
+	disk *storageTestDisk
+}
+
+func (s storageTestServices) Disk() service.DiskService { return s.disk }
+
+func useStorageTestService(t *testing.T, disk *storageTestDisk) {
+	t.Helper()
+	previous := service.MyService
+	service.MyService = storageTestServices{disk: disk}
+	t.Cleanup(func() { service.MyService = previous })
+}
+
+func storageTestRequest(t *testing.T, handler echo.HandlerFunc, path string, result interface{}) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	c := echo.New().NewContext(httptest.NewRequest("GET", path, nil), w)
+	if err := handler(c); err != nil {
+		t.Fatal(err)
+	}
+	if w.Code != 200 {
+		t.Fatalf("HTTP %d: %s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), result); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func storageTestRAID(mount string, partitioned bool) []model.LSBLKModel {
+	raid := model.LSBLKModel{Path: "/dev/md0", Name: "md0", Type: "raid10", Size: 2000, FsType: "ext4", MountPoint: mount, UUID: "raid-volume", Label: "storage", FSSize: "1900", FSAvail: "1800", FSUsed: "100"}
+	disks := []model.LSBLKModel{}
+	for _, name := range []string{"sda", "sdb", "sdc", "sdd"} {
+		member := model.LSBLKModel{Path: "/dev/" + name, Name: name, Type: "disk", Tran: "sata", Size: 1000, FsType: "linux_raid_member", Children: []model.LSBLKModel{raid}}
+		if partitioned {
+			part := member
+			part.Path, part.Type = member.Path+"1", "part"
+			member.FsType, member.Children = "", []model.LSBLKModel{part}
+		}
+		disks = append(disks, member)
+	}
+	return disks
+}
+
+func TestGetStorageListSharedRAID(t *testing.T) {
+	for _, partitioned := range []bool{false, true} {
+		disk := &storageTestDisk{disks: storageTestRAID("/mnt/storage", partitioned), dfError: errors.New("df unavailable")}
+		useStorageTestService(t, disk)
+		before, _ := json.Marshal(disk.disks)
+		var result struct {
+			Data []model.Storages `json:"data"`
+		}
+		storageTestRequest(t, GetStorageList, "/v1/storage", &result)
+		if len(result.Data) != 1 || len(result.Data[0].Children) != 1 {
+			t.Fatalf("duplicate array: %#v", result)
+		}
+		group := result.Data[0]
+		if group.Path != "/dev/md0" || group.Size != 2000 || group.DiskName != "RAID10" {
+			t.Fatalf("wrong parent: %#v", group)
+		}
+		volume := group.Children[0]
+		if volume.Path != "/dev/md0" || volume.Size != "1900" || volume.PersistedIn != "fstab" || volume.Label != "storage" {
+			t.Fatalf("lost volume metadata: %#v", volume)
+		}
+		after, _ := json.Marshal(disk.disks)
+		if string(before) != string(after) {
+			t.Fatal("physical tree changed")
+		}
+	}
+}
+
+func TestGetStorageListSystemRAID(t *testing.T) {
+	for _, partitioned := range []bool{false, true} {
+		for _, dfFailure := range []bool{false, true} {
+			disk := &storageTestDisk{disks: storageTestRAID("/", partitioned), systemPath: "/dev/md0"}
+			if dfFailure {
+				disk.dfError = errors.New("df unavailable")
+			}
+			useStorageTestService(t, disk)
+			var hidden struct {
+				Data []model.Storages `json:"data"`
+			}
+			storageTestRequest(t, GetStorageList, "/v1/storage", &hidden)
+			if len(hidden.Data) != 0 {
+				t.Fatal("system RAID exposed as user storage")
+			}
+			var shown struct {
+				Data []model.Storages `json:"data"`
+			}
+			storageTestRequest(t, GetStorageList, "/v1/storage?system=show", &shown)
+			if len(shown.Data) != 1 || shown.Data[0].DiskName != "System" {
+				t.Fatalf("system protection lost: %#v", shown)
+			}
+		}
+	}
+}
+
+func TestGetStorageListSystemAndUSB(t *testing.T) {
+	disk := &storageTestDisk{disks: []model.LSBLKModel{
+		{Path: "/dev/mmcblk0", Children: []model.LSBLKModel{
+			{Path: "/dev/mmcblk0p1", MountPoint: "/boot/firmware", FsType: "vfat"},
+			{Path: "/dev/mmcblk0p2", MountPoint: "/", FsType: "ext4"},
+			{Path: "/dev/mmcblk0p3", MountPoint: "/boot/efi", FsType: "vfat"},
+		}},
+		{Path: "/dev/sde", Tran: "usb", MountPoint: "/media/usb", FsType: "exfat", UUID: "usb"},
+	}, dfError: errors.New("df unavailable")}
+	useStorageTestService(t, disk)
+	var result struct {
+		Data []model.Storages `json:"data"`
+	}
+	storageTestRequest(t, GetStorageList, "/v1/storage?system=show", &result)
+	if len(result.Data) != 2 || len(result.Data[0].Children) != 2 || result.Data[0].DiskName != "System" || result.Data[1].Type != "usb" {
+		t.Fatalf("system/USB regression: %#v", result)
+	}
+	if result.Data[0].Children[1].Label != "System" || result.Data[1].Children[0].Label != "usb" {
+		t.Fatal("label fallback changed")
+	}
+}
+
+func TestGetDiskListKeepsRAIDMembers(t *testing.T) {
+	for _, partitioned := range []bool{false, true} {
+		disk := &storageTestDisk{disks: storageTestRAID("/mnt/storage", partitioned)}
+		useStorageTestService(t, disk)
+		var result struct {
+			Data struct {
+				Disks []model.Drive `json:"disks"`
+				Avail []model.Drive `json:"avail"`
+			} `json:"data"`
+		}
+		storageTestRequest(t, GetDiskList, "/v1/disks", &result)
+		if len(result.Data.Disks) != 4 || len(result.Data.Avail) != 0 || len(disk.smartPaths) != 4 {
+			t.Fatalf("lost or free RAID members: %#v, SMART=%v", result, disk.smartPaths)
+		}
+		for i, d := range result.Data.Disks {
+			if d.Path != disk.disks[i].Path || d.Size != 1000 {
+				t.Fatal("physical identity changed")
+			}
+		}
+	}
+}
+
+func TestDiskInUseUnassembledRAID(t *testing.T) {
+	member := model.LSBLKModel{FsType: "linux_raid_member"}
+	for _, disk := range []model.LSBLKModel{member, {Children: []model.LSBLKModel{member}}, {Children: []model.LSBLKModel{{Children: []model.LSBLKModel{{MountPoint: "/mnt/nested"}}}}}} {
+		if !diskInUse(disk) {
+			t.Fatal("member or nested mount offered as free")
+		}
+	}
+	if diskInUse(model.LSBLKModel{Path: "/dev/empty"}) {
+		t.Fatal("empty disk hidden")
+	}
+}


### PR DESCRIPTION
## Problem

On a Raspberry Pi 5 with four disks in a Linux MD RAID10, CasaOS shows the same mounted `storage` filesystem four times. The dashboard also counts its capacity repeatedly (7.27 TB instead of approximately 1.9 TB including the system filesystem).

`lsblk` correctly repeats a shared RAID device beneath each member, but LocalStorage treats these occurrences as independent storage. Its shallow traversal also misses nested mounted filesystems and can offer partitioned RAID members as available disks.

## Changes

- Add a read-only recursive mounted-volume view, deduplicated by device path and mount point, with logical RAID identity and capacity.
- Count each filesystem device once in capacity notifications, including repeated mount points.
- Preserve System classification, including root-on-RAID and failed `df` lookups.
- Preserve physical disk inventory and SMART queries; exclude nested mounted descendants and unassembled RAID signatures from available disks.
- Keep response fields, labels and mount-persistence metadata. Physical block-device topology is not modified.

This does not implement RAID creation, rebuild control or new RAID health monitoring. Formatting, mounting and removal handlers are unchanged.

## Reproduction

1. Use an existing mounted MD RAID10 with four whole-drive or partition members.
2. Open Storage Manager and inspect the storage API/capacity notifications.
3. Expect one logical mounted array, while the disk inventory retains all four physical members without offering them as available disks.

## Validation

- Go 1.21.13: `go generate`, `go test -p 4 -race -count=1 ./...`, and `go vet ./...` passed.
- Linux builds passed for amd64, arm64, ARMv7 and riscv64 with `CGO_ENABLED=0` and `-tags musl,netgo,osusergo`. These are compilation checks, not complete release/runtime QA.
- Regression tests reproduce duplicate array/system entries and incorrect availability classification on upstream `a9b12800df6ae9b27ef44ce800b857aa5334f565`, and pass with this change.
- Tests cover shared and partitioned RAID, partitions on RAID, root RAID, ordinary microSD/USB layouts, multiple arrays/mounts, identical labels/UUIDs on distinct devices, unavailable `df`, and input immutability.
- No destructive hardware tests were performed.

## Before / after

These real screenshots show the original LocalStorage **v0.4.4** and its local fix on the same NAS. This PR ports and improves that fix against current `main`; the newer main-based candidate has not been deployed to this NAS. The screenshots illustrate the original issue and local correction, while the tests above validate this branch.

### Before: four entries for the same md127 filesystem

<img width="640" height="985" alt="Before: four duplicate storage entries for md127" src="https://github.com/user-attachments/assets/b0d80bf8-e0fd-4496-975a-e79214c246d8" />

### After: one storage entry, with system volumes preserved

<img width="640" height="595" alt="After: one storage entry for md127" src="https://github.com/user-attachments/assets/a50d52f0-6f63-497d-9e00-ef549e6a69af" />

The fixed service was restored after capturing the before screenshot. The RAID remained healthy with all four members, and fstab/Samba configuration checksums were unchanged.

## Target branch

I could not find a `dev` branch in this repository; only `main` was available. Therefore I opened this PR against `main`, despite the general contribution guide recommending a development branch. This repository's PR CI also targets `main`. Please let me know if you prefer a different target branch.
